### PR TITLE
Multiple audio and subtitle stream support with windows compatability

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -127,7 +127,7 @@ class Converter(object):
                 raise ConverterError('Invalid video codec specification')
 
             if 'map' not in x:
-                opt['video']['map'] = 0
+                raise ConverterError('Must specify a map value')
 
             c = x['codec']
             if c not in self.video_codecs:

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -80,7 +80,7 @@ class Converter(object):
 
         if 'video' not in opt:
             opt['video'] = {'codec': None}
-            
+
         if 'subtitle' not in opt:
             opt['subtitle'][0] = {'codec': None}
 
@@ -102,7 +102,7 @@ class Converter(object):
                 audio_options.extend(self.audio_codecs[c]().parse_options(x, n))
                 if audio_options is None:
                     raise ConverterError('Unknown audio codec error')
-                    
+
         if 'subtitle' in opt:
             y = opt['subtitle']
             for n in y:
@@ -177,7 +177,7 @@ class Converter(object):
         using Converter in a threading environment, since the way the
         timeout is handled (using signals) has special restriction when
         using threads.
-               
+
         >>> conv = c.convert('test1.ogg', '/tmp/output.mkv', {
         ...    'format': 'mkv',
         ...    'audio': { 'codec': 'aac' },

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -137,7 +137,7 @@ class Converter(object):
             if video_options is None:
                 raise ConverterError('Unknown video codec error')
 
-        optlist = audio_options + video_options + subtitle_options + format_options
+        optlist = video_options + audio_options + subtitle_options + format_options
 
         if twopass == 1:
             optlist.extend(['-pass', '1'])

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -92,6 +92,9 @@ class Converter(object):
                 if not isinstance(x, dict) or 'codec' not in x:
                     raise ConverterError('Invalid audio codec specification')
 
+                if 'map' not in x:
+                    raise ConverterError('Must specify a map value')
+
                 c = x['codec']
                 if c not in self.audio_codecs:
                     raise ConverterError('Requested unknown audio codec ' + str(c))
@@ -107,6 +110,9 @@ class Converter(object):
                 if not isinstance(x, dict) or 'codec' not in x:
                     raise ConverterError('Invalid subtitle codec specification')
 
+                if 'map' not in x:
+                    raise ConverterError('Must specify a map value')
+
                 c = x['codec']
                 if c not in self.subtitle_codecs:
                     raise ConverterError('Requested unknown audio codec ' + str(c))
@@ -119,6 +125,9 @@ class Converter(object):
             x = opt['video']
             if not isinstance(x, dict) or 'codec' not in x:
                 raise ConverterError('Invalid video codec specification')
+
+            if 'map' not in x:
+                opt['video']['map'] = 0
 
             c = x['codec']
             if c not in self.video_codecs:

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -4,7 +4,7 @@
 import os
 import os.path
 
-from avcodecs import video_codec_list, audio_codec_list
+from avcodecs import video_codec_list, audio_codec_list, subtitle_codec_list
 from formats import format_list
 
 from ffmpeg import FFMpeg, FFMpegError, FFMpegConvertError
@@ -30,6 +30,7 @@ class Converter(object):
             ffprobe_path=ffprobe_path)
         self.video_codecs = {}
         self.audio_codecs = {}
+        self.subtitle_codecs = {}
         self.formats = {}
 
         for cls in audio_codec_list:
@@ -39,6 +40,10 @@ class Converter(object):
         for cls in video_codec_list:
             name = cls.codec_name
             self.video_codecs[name] = cls
+            
+        for cls in subtitle_codec_list:
+            name = cls.codec_name
+            self.subtitle_codecs[name] = cls
 
         for cls in format_list:
             name = cls.format_name
@@ -51,6 +56,7 @@ class Converter(object):
         format_options = None
         audio_options = []
         video_options = []
+        subtitle_options = []
 
         if not isinstance(opt, dict):
             raise ConverterError('Invalid output specification')
@@ -70,24 +76,44 @@ class Converter(object):
             raise ConverterError('Neither audio nor video streams requested')
 
         if 'audio' not in opt or twopass == 1:
-            opt['audio'] = {'codec': None}
+            opt['audio'][0] = {'codec': None}
 
         if 'video' not in opt:
             opt['video'] = {'codec': None}
+            
+        if 'subtitle' not in opt:
+            opt['subtitle'][0] = {'codec': None}
 
         if 'audio' in opt:
-            x = opt['audio']
+            y = opt['audio']
+            for n in y:
+                x = y[n]
 
-            if not isinstance(x, dict) or 'codec' not in x:
-                raise ConverterError('Invalid audio codec specification')
+                if not isinstance(x, dict) or 'codec' not in x:
+                    raise ConverterError('Invalid audio codec specification')
 
-            c = x['codec']
-            if c not in self.audio_codecs:
-                raise ConverterError('Requested unknown audio codec ' + str(c))
+                c = x['codec']
+                if c not in self.audio_codecs:
+                    raise ConverterError('Requested unknown audio codec ' + str(c))
 
-            audio_options = self.audio_codecs[c]().parse_options(x)
-            if audio_options is None:
-                raise ConverterError('Unknown audio codec error')
+                audio_options.extend(self.audio_codecs[c]().parse_options(x, n))
+                if audio_options is None:
+                    raise ConverterError('Unknown audio codec error')
+                    
+        if 'subtitle' in opt:
+            y = opt['subtitle']
+            for n in y:
+                x = y[n]
+                if not isinstance(x, dict) or 'codec' not in x:
+                    raise ConverterError('Invalid subtitle codec specification')
+
+                c = x['codec']
+                if c not in self.subtitle_codecs:
+                    raise ConverterError('Requested unknown audio codec ' + str(c))
+
+                subtitle_options.extend(self.subtitle_codecs[c]().parse_options(x, n))
+                if audio_options is None:
+                    raise ConverterError('Unknown audio codec error')
 
         if 'video' in opt:
             x = opt['video']
@@ -102,7 +128,7 @@ class Converter(object):
             if video_options is None:
                 raise ConverterError('Unknown video codec error')
 
-        optlist = audio_options + video_options + format_options
+        optlist = audio_options + video_options + subtitle_options + format_options
 
         if twopass == 1:
             optlist.extend(['-pass', '1'])
@@ -142,7 +168,7 @@ class Converter(object):
         using Converter in a threading environment, since the way the
         timeout is handled (using signals) has special restriction when
         using threads.
-
+               
         >>> conv = c.convert('test1.ogg', '/tmp/output.mkv', {
         ...    'format': 'mkv',
         ...    'audio': { 'codec': 'aac' },

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -375,7 +375,7 @@ class AudioCopyCodec(BaseCodec):
         optlist = []
         optlist.extend(['-c:a:'+stream, 'copy'])
         if 'map' in safe:
-            oplist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:'+str(safe['map'])])
         if 'language' in safe:
             l = safe['language']
             if len(l) > 3:

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -84,26 +84,27 @@ class AudioCodec(BaseCodec):
             l = safe['language']
             if len(l) > 3:
                 del safe['language']
-                
+
         safe = self._codec_specific_parse_options(safe)
 
-        optlist = ['-c:a:'+stream, self.ffmpeg_codec_name]
+        optlist = ['-c:a:' + stream, self.ffmpeg_codec_name]
         if 'map' in safe:
-            optlist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:' + str(safe['map'])])
         if 'channels' in safe:
-            optlist.extend(['-ac:a:'+stream, str(safe['channels'])])
+            optlist.extend(['-ac:a:' + stream, str(safe['channels'])])
         if 'bitrate' in safe:
-            optlist.extend(['-b:a:'+stream, str(safe['bitrate']) + 'k'])
+            optlist.extend(['-b:a:' + stream, str(safe['bitrate']) + 'k'])
         if 'samplerate' in safe:
-            optlist.extend(['-r:a:'+stream, str(safe['samplerate'])])
+            optlist.extend(['-r:a:' + stream, str(safe['samplerate'])])
         if 'language' in safe and safe['language'] != 'und':
                 lang = str(safe['language'])
         else:
             lang = 'eng'
-        optlist.extend(['-metadata:s:a:'+stream, "language=" + lang])
+        optlist.extend(['-metadata:s:a:' + stream, "language=" + lang])
 
         optlist.extend(self._codec_specific_produce_ffmpeg_list(safe))
         return optlist
+
 
 class SubtitleCodec(BaseCodec):
     """
@@ -116,7 +117,7 @@ class SubtitleCodec(BaseCodec):
 
     Supported subtitle codecs are: null (no subtitle), mov_text
     """
-    
+
     encoder_options = {
         'codec': str,
         'language': str,
@@ -134,34 +135,35 @@ class SubtitleCodec(BaseCodec):
             f = safe['forced']
             if f < 0 or f > 1:
                 del safe['forced']
-                
+
         if 'default' in safe:
             d = safe['default']
             if d < 0 or d > 1:
                 del safe['default']
-                
+
         if 'language' in safe:
             l = safe['language']
             if len(l) > 3:
                 del safe['language']
-        
+
         safe = self._codec_specific_parse_options(safe)
 
-        optlist = ['-c:s:'+stream, self.ffmpeg_codec_name]
+        optlist = ['-c:s:' + stream, self.ffmpeg_codec_name]
         if 'map' in safe:
-            optlist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:' + str(safe['map'])])
         if 'default' in safe:
-            optlist.extend(['-metadata:s:s:'+stream, "disposition:default=" + str(safe['default'])])
+            optlist.extend(['-metadata:s:s:' + stream, "disposition:default=" + str(safe['default'])])
         if 'forced' in safe:
-            optlist.extend(['-metadata:s:s:'+stream, "disposition:forced=" + str(safe['forced'])])
+            optlist.extend(['-metadata:s:s:' + stream, "disposition:forced=" + str(safe['forced'])])
         if 'language' in safe and safe['language'] != 'und':
                 lang = str(safe['language'])
         else:
             lang = 'eng'
-        optlist.extend(['-metadata:s:s:'+stream, "language=" + lang])
+        optlist.extend(['-metadata:s:s:' + stream, "language=" + lang])
 
         optlist.extend(self._codec_specific_produce_ffmpeg_list(safe))
         return optlist
+
 
 class VideoCodec(BaseCodec):
     """
@@ -325,7 +327,7 @@ class VideoCodec(BaseCodec):
 
         optlist = ['-vcodec', self.ffmpeg_codec_name]
         if 'map' in safe:
-            optlist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:' + str(safe['map'])])
         if 'fps' in safe:
             optlist.extend(['-r', str(safe['fps'])])
         if 'bitrate' in safe:
@@ -368,14 +370,14 @@ class AudioCopyCodec(BaseCodec):
     codec_name = 'copy'
     encoder_options = {'language': str,
                        'map': int}
-    
+
     def parse_options(self, opt, stream):
         safe = self.safe_options(opt)
         stream = str(stream)
         optlist = []
-        optlist.extend(['-c:a:'+stream, 'copy'])
+        optlist.extend(['-c:a:' + stream, 'copy'])
         if 'map' in safe:
-            optlist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:' + str(safe['map'])])
         if 'language' in safe:
             l = safe['language']
             if len(l) > 3:
@@ -384,7 +386,7 @@ class AudioCopyCodec(BaseCodec):
             lang = str(safe['language'])
         else:
             lang = 'eng'
-        optlist.extend(['-metadata:s:a:'+stream, "language=" + lang])
+        optlist.extend(['-metadata:s:a:' + stream, "language=" + lang])
         return optlist
 
 
@@ -400,7 +402,7 @@ class VideoCopyCodec(BaseCodec):
         optlist = []
         optlist.extend(['-vcodec', 'copy'])
         if 'map' in safe:
-            optlist.extend(['-map', '0:'+str(safe['map'])])
+            optlist.extend(['-map', '0:' + str(safe['map'])])
         return optlist
 
 
@@ -536,7 +538,8 @@ class Mpeg2Codec(MpegCodec):
     """
     codec_name = 'mpeg2'
     ffmpeg_codec_name = 'mpeg2video'
-    
+
+
 class MOVTextCodec(SubtitleCodec):
     """
     MOV Text video codec.

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -46,6 +46,7 @@ class AudioCodec(BaseCodec):
       * bitrate (integer) - stream bitrate
       * samplerate (integer) - sample rate (frequency)
       * language (str) - language of audio stream (3 char code)
+      * map (int) - stream index
 
     Supported audio codecs are: null (no audio), copy (copy from
     original), vorbis, aac, mp3, mp2

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -56,7 +56,8 @@ class AudioCodec(BaseCodec):
         'language': str,
         'channels': int,
         'bitrate': int,
-        'samplerate': int
+        'samplerate': int,
+        'map': int
     }
 
     def parse_options(self, opt, stream):
@@ -87,13 +88,15 @@ class AudioCodec(BaseCodec):
         safe = self._codec_specific_parse_options(safe)
 
         optlist = ['-c:a:'+stream, self.ffmpeg_codec_name]
+        if 'map' in safe:
+            optlist.extend(['-map', '0:'+str(safe['map'])])
         if 'channels' in safe:
             optlist.extend(['-ac:a:'+stream, str(safe['channels'])])
         if 'bitrate' in safe:
             optlist.extend(['-b:a:'+stream, str(safe['bitrate']) + 'k'])
         if 'samplerate' in safe:
             optlist.extend(['-r:a:'+stream, str(safe['samplerate'])])
-        if 'language' in safe:
+        if 'language' in safe and safe['language'] != 'und':
                 lang = str(safe['language'])
         else:
             lang = 'eng'
@@ -118,7 +121,8 @@ class SubtitleCodec(BaseCodec):
         'codec': str,
         'language': str,
         'forced': int,
-        'default': int
+        'default': int,
+        'map': int
     }
 
     def parse_options(self, opt, stream):
@@ -144,11 +148,13 @@ class SubtitleCodec(BaseCodec):
         safe = self._codec_specific_parse_options(safe)
 
         optlist = ['-c:s:'+stream, self.ffmpeg_codec_name]
+        if 'map' in safe:
+            optlist.extend(['-map', '0:'+str(safe['map'])])
         if 'default' in safe:
             optlist.extend(['-metadata:s:s:'+stream, "disposition:default=" + str(safe['default'])])
         if 'forced' in safe:
             optlist.extend(['-metadata:s:s:'+stream, "disposition:forced=" + str(safe['forced'])])
-        if 'language' in safe:
+        if 'language' in safe and safe['language'] != 'und':
                 lang = str(safe['language'])
         else:
             lang = 'eng'
@@ -195,6 +201,7 @@ class VideoCodec(BaseCodec):
         'mode': str,
         'src_width': int,
         'src_height': int,
+        'map': int
     }
 
     def _aspect_corrections(self, sw, sh, w, h, mode):
@@ -317,6 +324,8 @@ class VideoCodec(BaseCodec):
         filters = safe['aspect_filters']
 
         optlist = ['-vcodec', self.ffmpeg_codec_name]
+        if 'map' in safe:
+            optlist.extend(['-map', '0:'+str(safe['map'])])
         if 'fps' in safe:
             optlist.extend(['-r', str(safe['fps'])])
         if 'bitrate' in safe:
@@ -357,23 +366,26 @@ class AudioCopyCodec(BaseCodec):
     Copy audio stream directly from the source.
     """
     codec_name = 'copy'
-    encoder_options = {'language': str}
+    encoder_options = {'language': str,
+                       'map': int}
     
     def parse_options(self, opt, stream):
-            safe = self.safe_options(opt)
-            stream = str(stream)
-            optlist = []
-            optlist.extend(['-c:a:'+stream, 'copy'])
-            if 'language' in safe:
-                l = safe['language']
-                if len(l) > 3:
-                    del safe['language']
-            if 'language' in safe:
-                lang = str(safe['language'])
-            else:
-                lang = 'eng'
-            optlist.extend(['-metadata:s:a:'+stream, "language=" + lang])
-            return optlist
+        safe = self.safe_options(opt)
+        stream = str(stream)
+        optlist = []
+        optlist.extend(['-c:a:'+stream, 'copy'])
+        if 'map' in safe:
+            oplist.extend(['-map', '0:'+str(safe['map'])])
+        if 'language' in safe:
+            l = safe['language']
+            if len(l) > 3:
+                del safe['language']
+        if 'language' in safe:
+            lang = str(safe['language'])
+        else:
+            lang = 'eng'
+        optlist.extend(['-metadata:s:a:'+stream, "language=" + lang])
+        return optlist
 
 
 class VideoCopyCodec(BaseCodec):
@@ -381,9 +393,15 @@ class VideoCopyCodec(BaseCodec):
     Copy video stream directly from the source.
     """
     codec_name = 'copy'
+    encoder_options = {'map': int}
 
     def parse_options(self, opt):
-            return ['-vcodec', 'copy']
+        safe = self.safe_options(opt)
+        optlist = []
+        optlist.extend(['-vcodec', 'copy'])
+        if 'map' in safe:
+            optlist.extend(['-map', '0:'+str(safe['map'])])
+        return optlist
 
 
 class VorbisCodec(AudioCodec):

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -377,7 +377,6 @@ class FFMpeg(object):
             raise FFMpegError("Input file doesn't exist: " + infile)
 
         cmds = [self.ffmpeg_path, '-i', infile]
-        cmds.extend(['-map', '0'])
         cmds.extend(opts)
         cmds.extend(['-y', outfile])
 

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -150,7 +150,7 @@ class MediaStreamInfo(object):
                         self.video_fps = float(n) / float(d)
                 elif '.' in val:
                     self.video_fps = self.parse_float(val)
-        
+
         if self.type == 'subtitle':
             if key.lower() == 'disposition:forced':
                 self.sub_forced = self.parse_int(val)
@@ -238,7 +238,7 @@ class MediaInfo(object):
             if s.type == 'audio':
                 result.append(s)
         return result
-        
+
     @property
     def subtitle(self):
         """
@@ -249,6 +249,7 @@ class MediaInfo(object):
             if s.type == 'subtitle':
                 result.append(s)
         return result
+
 
 class FFMpeg(object):
     """
@@ -294,7 +295,7 @@ class FFMpeg(object):
 
     @staticmethod
     def _spawn(cmds, communicate=False):
-        if Popen and os.name!='nt':
+        if Popen and os.name != 'nt':
             p = Popen(cmds, shell=False,
                 stdin=PIPE, stdout=PIPE, stderr=PIPE,
                 close_fds=True)
@@ -302,7 +303,7 @@ class FFMpeg(object):
                     return p.communicate()
             else:
                 return (p.stdout, p.stderr)
-        elif Popen and os.name=='nt':
+        elif Popen and os.name == 'nt':
             p = Popen(cmds, shell=False,
                 stdin=PIPE, stdout=PIPE, stderr=PIPE,
                 close_fds=False)
@@ -344,7 +345,7 @@ class FFMpeg(object):
 
         raw, _ = self._spawn([self.ffprobe_path,
             '-show_format', '-show_streams', fname], True)
-        
+
         info.parse_ffprobe(raw)
 
         if not info.format.format and len(info.streams) == 0:
@@ -380,7 +381,7 @@ class FFMpeg(object):
         cmds.extend(opts)
         cmds.extend(['-y', outfile])
 
-        if timeout and os.name!='nt':
+        if timeout and os.name != 'nt':
             def on_sigalrm(*args):
                 signal.signal(signal.SIGALRM, signal.SIG_DFL)
                 raise Exception('timed out while waiting for ffmpeg')
@@ -397,12 +398,12 @@ class FFMpeg(object):
         total_output = ''
         pat = re.compile(r'time=([0-9.:]+) ')
         while True:
-            if timeout and os.name!='nt':
+            if timeout and os.name != 'nt':
                 signal.alarm(timeout)
 
             ret = fd.read(10)
 
-            if timeout and os.name!='nt':
+            if timeout and os.name != 'nt':
                 signal.alarm(0)
 
             if not ret:
@@ -426,7 +427,7 @@ class FFMpeg(object):
                     yielded = True
                     yield timecode
 
-        if timeout and os.name!='nt':
+        if timeout and os.name != 'nt':
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
         if total_output == '':

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -369,7 +369,7 @@ class FFMpeg(object):
         option.
 
         >>> conv = f.convert('test.ogg', '/tmp/output.mp3',
-        ...    ['-acodec libmp3lame', '-vn'])
+        ...    [0, ['-acodec libmp3lame', '-vn']])
         >>> for timecode in conv:
         ...    pass # can be used to inform the user about conversion progress
 

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -85,6 +85,9 @@ class MediaStreamInfo(object):
         self.video_fps = None
         self.audio_channels = None
         self.audio_samplerate = None
+        self.sub_forced = None
+        self.sub_default = None
+        self.language = None
 
     @staticmethod
     def parse_float(val, default=0.0):
@@ -123,6 +126,8 @@ class MediaStreamInfo(object):
             self.audio_channels = self.parse_int(val)
         elif key == 'sample_rate':
             self.audio_samplerate = self.parse_float(val)
+        elif key.lower() == 'tag:language':
+                self.language = val
 
         if self.type == 'audio':
             if key == 'avg_frame_rate':
@@ -145,6 +150,12 @@ class MediaStreamInfo(object):
                         self.video_fps = float(n) / float(d)
                 elif '.' in val:
                     self.video_fps = self.parse_float(val)
+        
+        if self.type == 'subtitle':
+            if key.lower() == 'disposition:forced':
+                self.sub_forced = self.parse_int(val)
+            if key.lower() == 'disposition:default':
+                self.sub_default = self.parse_int(val)
 
     def __repr__(self):
         d = ''
@@ -156,6 +167,8 @@ class MediaStreamInfo(object):
             d = 'type=%s, codec=%s, width=%d, height=%d, fps=%.1f' % (
                 self.type, self.codec, self.video_width, self.video_height,
                 self.video_fps)
+        elif self.type == 'subtitle':
+            d = 'type=%s, language=%s, forced=%d' % (self.type, self.sub_language, self.sub_forced)
         return 'MediaStreamInfo(%s)' % d
 
 
@@ -218,13 +231,24 @@ class MediaInfo(object):
     @property
     def audio(self):
         """
-        First audio stream, or None if there are no audio streams.
+        All audio streams
         """
+        result = []
         for s in self.streams:
             if s.type == 'audio':
-                return s
-        return None
-
+                result.append(s)
+        return result
+        
+    @property
+    def subtitle(self):
+        """
+        All subtitle streams
+        """
+        result = []
+        for s in self.streams:
+            if s.type == 'subtitle':
+                result.append(s)
+        return result
 
 class FFMpeg(object):
     """
@@ -343,10 +367,11 @@ class FFMpeg(object):
             raise FFMpegError("Input file doesn't exist: " + infile)
 
         cmds = [self.ffmpeg_path, '-i', infile]
+        cmds.extend(['-map', '0'])
         cmds.extend(opts)
         cmds.extend(['-y', outfile])
 
-        if timeout:
+        if timeout and os.name!='nt':
             def on_sigalrm(*args):
                 signal.signal(signal.SIGALRM, signal.SIG_DFL)
                 raise Exception('timed out while waiting for ffmpeg')
@@ -363,12 +388,12 @@ class FFMpeg(object):
         total_output = ''
         pat = re.compile(r'time=([0-9.:]+) ')
         while True:
-            if timeout:
+            if timeout and os.name!='nt':
                 signal.alarm(timeout)
 
             ret = fd.read(10)
 
-            if timeout:
+            if timeout and os.name!='nt':
                 signal.alarm(0)
 
             if not ret:
@@ -392,7 +417,7 @@ class FFMpeg(object):
                     yielded = True
                     yield timecode
 
-        if timeout:
+        if timeout and os.name!='nt':
             signal.signal(signal.SIGALRM, signal.SIG_DFL)
 
         if total_output == '':

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -294,10 +294,15 @@ class FFMpeg(object):
 
     @staticmethod
     def _spawn(cmds):
-        if Popen:
+        if Popen and os.name!='nt':
             p = Popen(cmds, shell=False,
                 stdin=PIPE, stdout=PIPE, stderr=PIPE,
                 close_fds=True)
+            return (p.stdout, p.stderr)
+        elif Popen and os.name=='nt':
+            p = Popen(cmds, shell=False,
+                stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                close_fds=False)
             return (p.stdout, p.stderr)
         else:
             pin, pout, perr = os.popen3(cmds)


### PR DESCRIPTION
- Added checks that will not run the portions of the code that aren't windows compatible
- Added support for multiple audio streams instead of one, the options would read something like:

```
{  'audio': { 
          0: {  'map': 1,
                 'channels': 2  },
          1: {  'map': 2,
                 'channels': 6  }
            }
}
```

_Map can be found from the index of the audio stream_
- Support for multiple subtitle channels as well

_Didn't update the tests_
