### PR TITLE
Parse video and audio stream metadata and fix a bunch of broken tests

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -257,8 +257,11 @@ class VideoCodec(BaseCodec):
         if 'bitrate' in safe:
             optlist.extend(['-vb', str(safe['bitrate']) + 'k']) # FIXED
         if w and h:
-            optlist.extend(['-s', '%dx%d' % (w, h),
-                '-aspect', '%d:%d' % (ow, oh)]) # FIXED
+            optlist.extend(['-s', '%dx%d' % (w, h)])
+
+            if ow and oh:
+                optlist.extend(['-aspect', '%d:%d' % (ow, oh)])
+
         if filters:
             optlist.extend(['-vf', filters])
 

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -90,6 +90,7 @@ class MediaStreamInfo(object):
       * codec - codec (short) name (e.g "vorbis", "theora")
       * codec_desc - codec full (descriptive) name
       * duration - stream duration in seconds
+      * metadata - optional metadata associated with a video or audio stream
     Video-specific attributes are:
       * video_width - width of video in pixels
       * video_height - height of video in pixels
@@ -110,6 +111,7 @@ class MediaStreamInfo(object):
         self.video_fps = None
         self.audio_channels = None
         self.audio_samplerate = None
+        self.metadata = {}
 
     @staticmethod
     def parse_float(val, default=0.0):
@@ -149,6 +151,11 @@ class MediaStreamInfo(object):
         elif key == 'sample_rate':
             self.audio_samplerate = self.parse_float(val)
 
+        if key.startswith('TAG:'):
+            key = key.split('TAG:')[1]
+            value = val
+            self.metadata[key] = value
+
         if self.type == 'audio':
             if key == 'avg_frame_rate':
                 if '/' in val:
@@ -172,7 +179,12 @@ class MediaStreamInfo(object):
                     self.video_fps = self.parse_float(val)
 
     def __repr__(self):
+        value = ''
         d = ''
+        metadata_str = ['%s=%s' % (key, value) for key, value
+                        in self.metadata.items()]
+        metadata_str = ', '.join(metadata_str)
+
         if self.type == 'audio':
             d = 'type=%s, codec=%s, channels=%d, rate=%.0f' % (self.type,
                 self.codec, self.audio_channels,
@@ -181,7 +193,13 @@ class MediaStreamInfo(object):
             d = 'type=%s, codec=%s, width=%d, height=%d, fps=%.1f' % (
                 self.type, self.codec, self.video_width, self.video_height,
                 self.video_fps)
-        return 'MediaStreamInfo(%s)' % d
+
+        if self.metadata:
+            value = 'MediaStreamInfo(%s, %s)' % (d, metadata_str)
+        else:
+            value = 'MediaStreamInfo(%s)' % (d)
+
+        return value
 
 
 class MediaInfo(object):

--- a/test/test.py
+++ b/test/test.py
@@ -150,29 +150,29 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(['-vcodec', 'doctest'],
             c.parse_options({'codec': 'doctest', 'fps': 0, 'bitrate': 0, 'width': 0, 'height': '480' }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-r', '25', '-b', '300k', '-s', '320x240', '-aspect', '320:240'],
+        self.assertEqual(['-vcodec', 'doctest', '-r', '25', '-vb', '300k', '-s', '320x240', '-aspect', '320:240'],
             c.parse_options({'codec': 'doctest', 'fps': '25', 'bitrate': '300', 'width': 320, 'height': 240 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '384x240', '-aspect', '384:240', '-vf', 'crop=32:0:320:240'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '384x240', '-aspect', '320:240', '-vf', 'crop=320:240:32:0'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 400, 'mode': 'crop',
                 'width': 320, 'height': 240 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240', '-aspect', '320:240', '-vf', 'crop=0:20:320:200'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240', '-aspect', '320:200', '-vf', 'crop=320:200:0:20'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 480, 'mode': 'crop',
                 'width': 320, 'height': 200 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '320x200', '-aspect', '320:200', '-vf', 'pad=320:240:0:20'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '320x200', '-aspect', '320:240', '-vf', 'pad=320:240:0:20'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 400, 'mode': 'pad',
                 'width': 320, 'height': 240 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '266x200', '-aspect', '266:200', '-vf', 'pad=320:200:27:0'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '266x200', '-aspect', '320:200', '-vf', 'pad=320:200:27:0'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 480, 'mode': 'pad',
                 'width': 320, 'height': 200 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240', '-aspect', '320:240'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 480, 'width': 320 }))
 
-        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240', '-aspect', '320:240'],
+        self.assertEqual(['-vcodec', 'doctest', '-s', '320x240'],
             c.parse_options({'codec': 'doctest', 'src_width': 640, 'src_height': 480, 'height': 240 }))
 
     def test_converter(self):

--- a/test/test.py
+++ b/test/test.py
@@ -53,6 +53,7 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(720, v.video_width)
         self.assertEqual(400, v.video_height)
         self.assertAlmostEqual(25.00, v.video_fps, places=2)
+        self.assertEqual(v.metadata['ENCODER'], 'ffmpeg2theora 0.19')
 
         a = info.streams[1]
         self.assertEqual(a, info.audio)
@@ -60,9 +61,10 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual('vorbis', a.codec)
         self.assertEqual(2, a.audio_channels)
         self.assertEqual(48000, a.audio_samplerate)
+        self.assertEqual(a.metadata['ENCODER'], 'ffmpeg2theora 0.19')
 
         self.assertEqual(repr(info),
-            'MediaInfo(format=MediaFormatInfo(format=ogg, duration=33.00), streams=[MediaStreamInfo(type=video, codec=theora, width=720, height=400, fps=25.0), MediaStreamInfo(type=audio, codec=vorbis, channels=2, rate=48000)])')
+            'MediaInfo(format=MediaFormatInfo(format=ogg, duration=33.00), streams=[MediaStreamInfo(type=video, codec=theora, width=720, height=400, fps=25.0, ENCODER=ffmpeg2theora 0.19), MediaStreamInfo(type=audio, codec=vorbis, channels=2, rate=48000, ENCODER=ffmpeg2theora 0.19)])')
 
     def test_ffmpeg_convert(self):
         f = ffmpeg.FFMpeg()


### PR DESCRIPTION
# Problem

Current version doesn't support parsing video and audio stream metadata. Video and audio metadata can be very useful, because it can contain different information such as video orientation, etc.
# Proposed solution

This pull request adds support for parsing optional metadata which can be supplied with each audio and video stream. It also includes tests for this new functionality.
# Other changes in this pull request
1. Fixes a bunch of tests which were broken as part of #11.
2. Fixes a bug with specifying `-aspect` option even if both, source width and height weren't specified. This bug was introduced as part of #11.
3. To prevent issues like this from happening in the future (regressions), I'm working on hooking up tests with Travis CI. I will open a separate PR once it's ready and working.

All the tests pass now

``` bash
$ python setup.py test
running test
......
----------------------------------------------------------------------
Ran 6 tests in 5.349s

OK
```
