### PR TITLE
Create multiple thumbnails in one ffmpeg call

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -197,12 +197,12 @@ class Converter(object):
         """
         return self.ffmpeg.probe(fname)
 
-    def thumbnail(self, fname, time, outfile, size=None):
+    def thumbnail(self, fname, time, outfile, size=None, quality=FFMpeg.DEFAULT_JPEG_QUALITY):
         """
         Create a thumbnail of the media file. See the documentation of
         converter.FFMpeg.thumbnail() for details.
         """
-        return self.ffmpeg.thumbnail(fname, time, outfile, size)
+        return self.ffmpeg.thumbnail(fname, time, outfile, size, quality)
 
     def thumbnails(self, fname, option_list):
         """

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -203,3 +203,10 @@ class Converter(object):
         converter.FFMpeg.thumbnail() for details.
         """
         return self.ffmpeg.thumbnail(fname, time, outfile, size)
+
+    def thumbnails(self, fname, option_list):
+        """
+        Create one or more thumbnail of the media file. See the documentation
+        of converter.FFMpeg.thumbnails() for details.
+        """
+        return self.ffmpeg.thumbnails(fname, option_list)

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -276,6 +276,7 @@ class FFMpeg(object):
 
     >>> f = FFMpeg()
     """
+    DEFAULT_JPEG_QUALITY = 2
 
     def __init__(self, ffmpeg_path=None, ffprobe_path=None):
         """
@@ -456,37 +457,41 @@ class FFMpeg(object):
                     raise FFMpegConvertError('Unknown ffmpeg error', cmd,
                                              total_output, line)
 
-    def thumbnail(self, fname, time, outfile, size=None):
+    def thumbnail(self, fname, time, outfile, size=None, quality=DEFAULT_JPEG_QUALITY):
         """
         Create a thumbnal of media file, and store it to outfile
         @param time: time point (in seconds) (float or int)
         @param size: Size, if specified, is WxH of the desired thumbnail.
             If not specified, the video resolution is used.
+        @param quality: quality of jpeg file in range 2(best)-31(worst)
+            recommended range: 2-6
 
         >>> f.thumbnail('test1.ogg', 5, '/tmp/shot.png', '320x240')
         """
-        return self.thumbnails(fname, [(time, outfile, size)])
+        return self.thumbnails(fname, [(time, outfile, size, quality)])
 
     def thumbnails(self, fname, option_list):
         """
         Create one or more thumbnails of video.
-        @param option_list: a list of tuples like (time, outfile, size)
+        @param option_list: a list of tuples like:
+            (time, outfile, size=None, quality=DEFAULT_JPEG_QUALITY)
             see documentation of `converter.FFMpeg.thumbnail()` for details.
 
         >>> f.thumbnails('test1.ogg', [(5, '/tmp/shot.png', '320x240'),
-        >>>                            (10, '/tmp/shot2.png', None)])
+        >>>                            (10, '/tmp/shot2.png', None, 5)])
         """
         if not os.path.exists(fname):
             raise IOError('No such file: ' + fname)
 
         cmds = [self.ffmpeg_path, '-i', fname, '-y', '-an']
-        for time, outfile, size in option_list:
-            if size:
-                cmds.extend(['-s', str(size)])
+        for thumb in option_list:
+            if len(thumb) > 2 and thumb[2]:
+                cmds.extend(['-s', str(thumb[2])])
 
             cmds.extend([
-                '-f', 'image2', '-q:v', '0', '-vframes', '1',
-                '-ss', str(time), outfile
+                '-f', 'image2', '-vframes', '1',
+                '-ss', str(thumb[0]), thumb[1],
+                '-q:v', str(FFMpeg.DEFAULT_JPEG_QUALITY if len(thumb) < 4 else str(thumb[3])),
             ])
 
         _, fd = self._spawn(cmds)

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -276,7 +276,7 @@ class FFMpeg(object):
 
     >>> f = FFMpeg()
     """
-    DEFAULT_JPEG_QUALITY = 2
+    DEFAULT_JPEG_QUALITY = 4
 
     def __init__(self, ffmpeg_path=None, ffprobe_path=None):
         """

--- a/test/test.py
+++ b/test/test.py
@@ -29,6 +29,7 @@ class TestFFMpeg(unittest.TestCase):
 
         self.video_file_path = pjoin(self.temp_dir, 'output.ogg')
         self.shot_file_path = pjoin(self.temp_dir, 'shot.png')
+        self.shot2_file_path = pjoin(self.temp_dir, 'shot2.png')
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
@@ -122,6 +123,7 @@ class TestFFMpeg(unittest.TestCase):
     def test_ffmpeg_thumbnail(self):
         f = ffmpeg.FFMpeg()
         thumb = self.shot_file_path
+        thumb2 = self.shot2_file_path
 
         self.assertRaisesSpecific(IOError, f.thumbnail, 'nonexistent', 10, thumb)
 
@@ -132,6 +134,14 @@ class TestFFMpeg(unittest.TestCase):
         self.ensure_notexist(thumb)
         self.assertRaisesSpecific(ffmpeg.FFMpegError, f.thumbnail, 'test1.ogg', 34, thumb)
         self.assertFalse(os.path.exists(thumb))
+
+        # test multiple thumbnail
+        self.ensure_notexist(thumb)
+        self.ensure_notexist(thumb2)
+        f.thumbnails('test1.ogg', [
+            (5, thumb, '320x240'),
+            (10, thumb2, None),
+        ])
 
     def test_formats(self):
         c = formats.BaseFormat()

--- a/test/test.py
+++ b/test/test.py
@@ -144,6 +144,9 @@ class TestFFMpeg(unittest.TestCase):
             (10, thumb2, None, 5),  # set quality
             (5, self.shot3_file_path, '320x240'),  # set size
         ])
+        self.assertTrue(os.path.exists(thumb))
+        self.assertTrue(os.path.exists(thumb2))
+        self.assertTrue(os.path.exists(self.shot3_file_path))
 
     def test_formats(self):
         c = formats.BaseFormat()

--- a/test/test.py
+++ b/test/test.py
@@ -30,6 +30,7 @@ class TestFFMpeg(unittest.TestCase):
         self.video_file_path = pjoin(self.temp_dir, 'output.ogg')
         self.shot_file_path = pjoin(self.temp_dir, 'shot.png')
         self.shot2_file_path = pjoin(self.temp_dir, 'shot2.png')
+        self.shot3_file_path = pjoin(self.temp_dir, 'shot3.png')
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
@@ -139,8 +140,9 @@ class TestFFMpeg(unittest.TestCase):
         self.ensure_notexist(thumb)
         self.ensure_notexist(thumb2)
         f.thumbnails('test1.ogg', [
-            (5, thumb, '320x240'),
-            (10, thumb2, None),
+            (5, thumb),
+            (10, thumb2, None, 5),  # set quality
+            (5, self.shot3_file_path, '320x240'),  # set size
         ])
 
     def test_formats(self):


### PR DESCRIPTION
Add a method to `FFMpeg` to allow creating multiple thumbnails with one `ffmpeg` call.
