### PR TITLE
Convert doesn't throw any Exception when ffmpeg is killed by a signal

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -4,14 +4,10 @@ import os.path
 import os
 import re
 import signal
+from subprocess import Popen, PIPE
 import logging
 
 logger = logging.getLogger(__name__)
-
-try:
-    from subprocess import Popen, PIPE
-except:
-    Popen = None
 
 
 class FFMpegError(Exception):
@@ -322,15 +318,9 @@ class FFMpeg(object):
 
     @staticmethod
     def _spawn(cmds):
-        if Popen:
-            logger.debug('Spawning ffmpeg with command: ' + ' '.join(cmds))
-            p = Popen(cmds, shell=False,
-                stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                close_fds=True)
-            return (p.stdout, p.stderr)
-        else:
-            pin, pout, perr = os.popen3(cmds)
-            return (pout, perr)
+        logger.debug('Spawning ffmpeg with command: ' + ' '.join(cmds))
+        return Popen(cmds, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE,
+                     close_fds=True)
 
     def probe(self, fname):
         """
@@ -360,11 +350,11 @@ class FFMpeg(object):
 
         info = MediaInfo()
 
-        fd, _ = self._spawn([self.ffprobe_path,
+        p = self._spawn([self.ffprobe_path,
             '-show_format', '-show_streams', fname])
-        raw = fd.read()
+        stdout_data, _ = p.communicate()
 
-        info.parse_ffprobe(raw)
+        info.parse_ffprobe(stdout_data)
 
         if not info.format.format and len(info.streams) == 0:
             return None
@@ -407,7 +397,7 @@ class FFMpeg(object):
             signal.signal(signal.SIGALRM, on_sigalrm)
 
         try:
-            _, fd = self._spawn(cmds)
+            p = self._spawn(cmds)
         except OSError:
             raise FFMpegError('Error while calling ffmpeg binary')
 
@@ -419,7 +409,7 @@ class FFMpeg(object):
             if timeout:
                 signal.alarm(timeout)
 
-            ret = fd.read(10)
+            ret = p.stderr.read(10)
 
             if timeout:
                 signal.alarm(0)
@@ -503,10 +493,10 @@ class FFMpeg(object):
                 '-q:v', str(FFMpeg.DEFAULT_JPEG_QUALITY if len(thumb) < 4 else str(thumb[3])),
             ])
 
-        _, fd = self._spawn(cmds)
-        output = fd.read()
-        if output == '':
+        p = self._spawn(cmds)
+        _, stderr_data = p.communicate()
+        if stderr_data == '':
             raise FFMpegError('Error while calling ffmpeg binary')
 
         if any(not os.path.exists(option[1]) for option in option_list):
-            raise FFMpegError('Error creating thumbnail: %s' % output)
+            raise FFMpegError('Error creating thumbnail: %s' % stderr_data)

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -361,7 +361,7 @@ class FFMpeg(object):
 
         return info
 
-    def convert(self, infile, outfile, opts, timeout=10):
+    def convert(self, infile, outfile, opts, timeout=10, yield_process=False):
         """
         Convert the source media (infile) according to specified options
         (a list of ffmpeg switches as strings) and save it to outfile.
@@ -400,6 +400,9 @@ class FFMpeg(object):
             p = self._spawn(cmds)
         except OSError:
             raise FFMpegError('Error while calling ffmpeg binary')
+
+        if yield_process:
+            yield p
 
         yielded = False
         buf = ''

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -361,7 +361,7 @@ class FFMpeg(object):
 
         return info
 
-    def convert(self, infile, outfile, opts, timeout=10, yield_process=False):
+    def convert(self, infile, outfile, opts, timeout=10):
         """
         Convert the source media (infile) according to specified options
         (a list of ffmpeg switches as strings) and save it to outfile.
@@ -400,9 +400,6 @@ class FFMpeg(object):
             p = self._spawn(cmds)
         except OSError:
             raise FFMpegError('Error while calling ffmpeg binary')
-
-        if yield_process:
-            yield p
 
         yielded = False
         buf = ''

--- a/test/test.py
+++ b/test/test.py
@@ -158,7 +158,7 @@ class TestFFMpeg(unittest.TestCase):
         p = conv.next()  # get process object
         conv.next()  # let ffmpeg to start
         p.terminate()
-        self.assertRaisesSpecific(ffmpeg.FFMpegError, list, conv)
+        self.assertRaisesSpecific(ffmpeg.FFMpegConvertError, list, conv)
 
 
     def test_ffmpeg_thumbnail(self):

--- a/test/test.py
+++ b/test/test.py
@@ -152,11 +152,17 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(1, info.audio.audio_channels)
         self.assertEqual(11025, info.audio.audio_samplerate)
 
+    def test_ffmpeg_termination(self):
         # test when ffmpeg is killed
-        conv = f.convert('test1.ogg', self.video_file_path, convert_options,
-                         yield_process=True)
-        p = conv.next()  # get process object
+        f = ffmpeg.FFMpeg()
+        convert_options = [
+            '-acodec', 'libvorbis', '-ab', '16k', '-ac', '1', '-ar', '11025',
+             '-vcodec', 'libtheora', '-r', '15', '-s', '360x200', '-b', '128k']
+        p_list = {}  # modifiable object in closure
+        f._spawn = lambda *args: p_list.setdefault('', ffmpeg.FFMpeg._spawn(*args))
+        conv = f.convert('test1.ogg', self.video_file_path, convert_options)
         conv.next()  # let ffmpeg to start
+        p = p_list['']
         p.terminate()
         self.assertRaisesSpecific(ffmpeg.FFMpegConvertError, list, conv)
 

--- a/test/test.py
+++ b/test/test.py
@@ -120,10 +120,10 @@ class TestFFMpeg(unittest.TestCase):
 
         info = f.probe('test1.ogg')
 
-        conv = f.convert('test1.ogg', self.video_file_path, [
+        convert_options = [
             '-acodec', 'libvorbis', '-ab', '16k', '-ac', '1', '-ar', '11025',
-            '-vcodec', 'libtheora', '-r', '15', '-s', '360x200', '-b', '128k'
-        ])
+             '-vcodec', 'libtheora', '-r', '15', '-s', '360x200', '-b', '128k']
+        conv = f.convert('test1.ogg', self.video_file_path, convert_options)
 
         last_tc = 0.0
         for tc in conv:
@@ -151,6 +151,15 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual('vorbis', info.audio.codec)
         self.assertEqual(1, info.audio.audio_channels)
         self.assertEqual(11025, info.audio.audio_samplerate)
+
+        # test when ffmpeg is killed
+        conv = f.convert('test1.ogg', self.video_file_path, convert_options,
+                         yield_process=True)
+        p = conv.next()  # get process object
+        conv.next()  # let ffmpeg to start
+        p.terminate()
+        self.assertRaisesSpecific(ffmpeg.FFMpegError, list, conv)
+
 
     def test_ffmpeg_thumbnail(self):
         f = ffmpeg.FFMpeg()


### PR DESCRIPTION
With these changes, if `ffmpeg` killed by a signal or exited with a non-zero return code, a `FFMpegConvertError` will be raised.
