### PR TITLE
Update avcodecs.py

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -384,7 +384,7 @@ class Vp8Codec(VideoCodec):
     Google VP8 video codec.
     """
     codec_name = 'vp8'
-    ffmpeg_codec_name = 'vp8'
+    ffmpeg_codec_name = 'libvpx'
 
 
 class H263Codec(VideoCodec):


### PR DESCRIPTION
This change already merged into master, now we can merge the branch from `ouhoushsami` to minimize unmerged branches.

propose to use libvpx instead of vp8 for webm video encoding (see here: http://ffmpeg.org/trac/ffmpeg/wiki/vpxEncodingGuide)
