### PR TITLE
Faster travis build

### DIFF
--- a/test/install-ffmpeg.sh
+++ b/test/install-ffmpeg.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
-add-apt-repository -y ppa:jon-severinsson/ffmpeg
-apt-get -y -qq update
-apt-get -y -qq install ffmpeg
+## tests fails with jon-severinsson binaries (version 0.10.7)
+# add-apt-repository -y ppa:jon-severinsson/ffmpeg
+# apt-get -y -qq update
+# apt-get -y -qq install ffmpeg
+
+wget -P /tmp http://ffmpeg.gusari.org/static/64bit/ffmpeg.static.64bit.2013-06-28.tar.gz
+tar -xvf /tmp/ffmpeg.static.64bit.2013-06-28.tar.gz -C /usr/local/bin

--- a/test/install-ffmpeg.sh
+++ b/test/install-ffmpeg.sh
@@ -2,36 +2,17 @@
 # Based on https://raw.github.com/christianselig/islandora_solution_pack_video/7.x/ffmpeg-install.sh
 
 apt-get -y update
-apt-get -y install libjpeg-dev libpng12-dev libtiff4-dev php5 php5-cli php5-curl php5-dev php5-gd php5-ldap php5-mysql php5-xsl php-soap php-xml-htmlsax3 php-xml-parser php-xml-rpc php-xml-rpc2 php-xml-rss php-xml-serializer php5-imagick php5-mcrypt php-xml* mysql-server vim curl apache2 rsync wget imagemagick ant libimage-exiftool-perl unzip lame autoconf build-essential checkinstall git libass-dev libfaac-dev libgpac-dev libmp3lame-dev libopencore-amrnb-dev libopencore-amrwb-dev librtmp-dev libtheora-dev libtool libvorbis-dev pkg-config texi2html zlib1g-dev ffmpeg2theora poppler-utils
+apt-get -y install yasm lame autoconf build-essential checkinstall libvpx-dev libmp3lame-dev \
+	libtheora-dev libvorbis-dev libx264-dev
 
 ## Install ffmpeg from source
 mkdir ~/ffmpeg-source
 cd ~/ffmpeg-source
-wget http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz
-tar xzvf yasm-1.2.0.tar.gz && rm -rf yasm-1.2.0.tar.gz
-cd yasm-1.2.0
-./configure
-make
-checkinstall --pkgname=yasm --pkgversion="1.2.0" --backup=no --deldoc=yes --fstrans=no --default
-cd ~/ffmpeg-source
-git clone git://git.videolan.org/x264.git
-cd x264
-./configure --enable-static --enable-shared
-make
-checkinstall --pkgname=x264 --pkgversion="3:$(./version.sh | awk -F'[" ]' '/POINT/{print $4"+git"$5}')" --backup=no --deldoc=yes  --fstrans=no --default
-ldconfig
-cd ~/ffmpeg-source
-git clone --depth 1 http://git.chromium.org/webm/libvpx.git
-cd libvpx
-./configure --disable-examples --disable-unit-tests
-make
-checkinstall --pkgname=libvpx --pkgversion="1:$(date +%Y%m%d%H%M)-git" --backup=no --deldoc=yes --fstrans=no --default
-cd ~/ffmpeg-source
 wget http://www.ffmpeg.org/releases/ffmpeg-1.1.1.tar.gz
 tar xf ffmpeg-1.1.1.tar.gz && rm -rf ffmpeg-1.1.1.tar.gz
 cd ffmpeg-1.1.1
-./configure --enable-gpl --enable-libass --enable-libfaac --enable-libmp3lame --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-librtmp \
---enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-nonfree --enable-version3
+# don't configure with --enable-nonfree to allow distributin pre-build binaries
+./configure --enable-gpl --enable-libmp3lame --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264
 make
 checkinstall --pkgname=ffmpeg --pkgversion="7:$(date +%Y%m%d%H%M)-git" --backup=no --deldoc=yes --fstrans=no --default
 hash -r

--- a/test/install-ffmpeg.sh
+++ b/test/install-ffmpeg.sh
@@ -1,19 +1,5 @@
 #!/usr/bin/env bash
-# Based on https://raw.github.com/christianselig/islandora_solution_pack_video/7.x/ffmpeg-install.sh
 
-apt-get -y update
-apt-get -y install yasm lame autoconf build-essential checkinstall libvpx-dev libmp3lame-dev \
-	libtheora-dev libvorbis-dev libx264-dev
-
-## Install ffmpeg from source
-mkdir ~/ffmpeg-source
-cd ~/ffmpeg-source
-wget http://www.ffmpeg.org/releases/ffmpeg-1.1.1.tar.gz
-tar xf ffmpeg-1.1.1.tar.gz && rm -rf ffmpeg-1.1.1.tar.gz
-cd ffmpeg-1.1.1
-# don't configure with --enable-nonfree to allow distributin pre-build binaries
-./configure --enable-gpl --enable-libmp3lame --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264
-make
-checkinstall --pkgname=ffmpeg --pkgversion="7:$(date +%Y%m%d%H%M)-git" --backup=no --deldoc=yes --fstrans=no --default
-hash -r
-cd ~
+add-apt-repository -y ppa:jon-severinsson/ffmpeg
+apt-get -y -qq update
+apt-get -y -qq install ffmpeg


### PR DESCRIPTION
Using pre-built ffmpeg binaries, the test runtime dropped from 40min to less than 2 minutes.
