### PR TITLE
Sickbeard-mp4-automator merge

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -162,7 +162,7 @@ class Converter(object):
 
         return optlist
 
-    def convert(self, infile, outfile, options, twopass=False, timeout=10):
+    def convert(self, infile, outfile, options, twopass=False, timeout=10, preopts=None, postopts=None):
         """
         Convert media file (infile) according to specified options, and
         save it to outfile. For two-pass encoding, specify the pass (1 or 2)
@@ -230,17 +230,17 @@ class Converter(object):
         if twopass:
             optlist1 = self.parse_options(options, 1)
             for timecode in self.ffmpeg.convert(infile, outfile, optlist1,
-                                                timeout=timeout):
+                                                timeout=timeout, preopts=preopts, postopts=postopts):
                 yield int((50.0 * timecode) / info.format.duration)
 
             optlist2 = self.parse_options(options, 2)
             for timecode in self.ffmpeg.convert(infile, outfile, optlist2,
-                                                timeout=timeout):
+                                                timeout=timeout, preopts=preopts, postopts=postopts):
                 yield int(50.0 + (50.0 * timecode) / info.format.duration)
         else:
             optlist = self.parse_options(options, twopass)
             for timecode in self.ffmpeg.convert(infile, outfile, optlist,
-                                                timeout=timeout):
+                                                timeout=timeout, preopts=preopts, postopts=postopts):
                 yield int((100.0 * timecode) / info.format.duration)
 
     def probe(self, fname, posters_as_video=True):

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -83,7 +83,7 @@ class Converter(object):
 
         # Creates the new nested dictionary to preserve backwards compatability
         try:
-            first = y.values()[0]
+            first = list(y.values())[0]
             if not isinstance(first, dict):
                 y = {0: y}
         except IndexError:
@@ -114,7 +114,7 @@ class Converter(object):
 
         # Creates the new nested dictionary to preserve backwards compatability
         try:
-            first = y.values()[0]
+            first = list(y.values())[0]
             if not isinstance(first, dict):
                 y = {0: y}
         except IndexError:

--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -72,66 +72,72 @@ class Converter(object):
         if 'audio' not in opt and 'video' not in opt and 'subtitle' not in opt:
             raise ConverterError('Neither audio nor video nor subtitle streams requested')
 
-        if 'audio' in opt:
-            y = opt['audio']
+        if 'audio' not in opt:
+            opt['audio'] = {'codec': None}
 
-            # Creates the new nested dictionary to preserve backwards compatability
-            try:
-                first = y.values()[0]
-                if not isinstance(first, dict) and first is not None:
-                    y = {0: y}
-            except IndexError:
-                pass
+        if 'subtitle' not in opt:
+            opt['subtitle'] = {'codec': None}
 
-            for n in y:
-                x = y[n]
+        # Audio
+        y = opt['audio']
 
-                if not isinstance(x, dict) or 'codec' not in x:
-                    raise ConverterError('Invalid audio codec specification')
+        # Creates the new nested dictionary to preserve backwards compatability
+        try:
+            first = y.values()[0]
+            if not isinstance(first, dict):
+                y = {0: y}
+        except IndexError:
+            pass
 
-                if 'path' in x and 'source' not in x:
-                    raise ConverterError('Cannot specify audio path without FFMPEG source number')
+        for n in y:
+            x = y[n]
 
-                if 'source' in x and 'path' not in x:
-                    raise ConverterError('Cannot specify alternate input source without a path')
+            if not isinstance(x, dict) or 'codec' not in x:
+                raise ConverterError('Invalid audio codec specification')
 
-                c = x['codec']
-                if c not in self.audio_codecs:
-                    raise ConverterError('Requested unknown audio codec ' + str(c))
+            if 'path' in x and 'source' not in x:
+                raise ConverterError('Cannot specify audio path without FFMPEG source number')
 
-                audio_options.extend(self.audio_codecs[c]().parse_options(x, n))
-                if audio_options is None:
-                    raise ConverterError('Unknown audio codec error')
+            if 'source' in x and 'path' not in x:
+                raise ConverterError('Cannot specify alternate input source without a path')
 
-        if 'subtitle' in opt:
-            y = opt['subtitle']
+            c = x['codec']
+            if c not in self.audio_codecs:
+                raise ConverterError('Requested unknown audio codec ' + str(c))
 
-            # Creates the new nested dictionary to preserve backwards compatability
-            try:
-                first = y.values()[0]
-                if not isinstance(first, dict) and first is not None:
-                    y = {0: y}
-            except IndexError:
-                pass
+            audio_options.extend(self.audio_codecs[c]().parse_options(x, n))
+            if audio_options is None:
+                raise ConverterError('Unknown audio codec error')
 
-            for n in y:
-                x = y[n]
-                if not isinstance(x, dict) or 'codec' not in x:
-                    raise ConverterError('Invalid subtitle codec specification')
+        # Subtitle
+        y = opt['subtitle']
 
-                if 'path' in x and 'source' not in x:
-                    raise ConverterError('Cannot specify subtitle path without FFMPEG source number')
+        # Creates the new nested dictionary to preserve backwards compatability
+        try:
+            first = y.values()[0]
+            if not isinstance(first, dict):
+                y = {0: y}
+        except IndexError:
+            pass
 
-                if 'source' in x and 'path' not in x:
-                    raise ConverterError('Cannot specify alternate input source without a path')
+        for n in y:
+            x = y[n]
+            if not isinstance(x, dict) or 'codec' not in x:
+                raise ConverterError('Invalid subtitle codec specification')
 
-                c = x['codec']
-                if c not in self.subtitle_codecs:
-                    raise ConverterError('Requested unknown subtitle codec ' + str(c))
+            if 'path' in x and 'source' not in x:
+                raise ConverterError('Cannot specify subtitle path without FFMPEG source number')
 
-                subtitle_options.extend(self.subtitle_codecs[c]().parse_options(x, n))
-                if subtitle_options is None:
-                    raise ConverterError('Unknown subtitle codec error')
+            if 'source' in x and 'path' not in x:
+                raise ConverterError('Cannot specify alternate input source without a path')
+
+            c = x['codec']
+            if c not in self.subtitle_codecs:
+                raise ConverterError('Requested unknown subtitle codec ' + str(c))
+
+            subtitle_options.extend(self.subtitle_codecs[c]().parse_options(x, n))
+            if subtitle_options is None:
+                raise ConverterError('Unknown subtitle codec error')
 
         if 'video' in opt:
             x = opt['video']

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -105,7 +105,7 @@ class AudioCodec(BaseCodec):
         if 'bitrate' in safe:
             optlist.extend(['-b:a:' + stream, str(safe['bitrate']) + 'k'])
         if 'samplerate' in safe:
-            optlist.extend(['-r:a:' + stream, str(safe['samplerate'])])
+            optlist.extend(['-ar:a:' + stream, str(safe['samplerate'])])
         if 'language' in safe:
                 lang = str(safe['language'])
         else:

--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -60,6 +60,7 @@ class AudioCodec(BaseCodec):
         'samplerate': int,
         'source': int,
         'path' : str,
+        'filter' : str,
         'map': int
     }
 
@@ -75,8 +76,10 @@ class AudioCodec(BaseCodec):
 
         if 'bitrate' in safe:
             br = safe['bitrate']
-            if br < 8 or br > 1536:
-                del safe['bitrate']
+            if br < 8:
+                br = 8
+            if br > 1536:
+                br = 1536
 
         if 'samplerate' in safe:
             f = safe['samplerate']
@@ -103,9 +106,11 @@ class AudioCodec(BaseCodec):
         if 'channels' in safe:
             optlist.extend(['-ac:a:' + stream, str(safe['channels'])])
         if 'bitrate' in safe:
-            optlist.extend(['-b:a:' + stream, str(safe['bitrate']) + 'k'])
+            optlist.extend(['-b:a:' + stream, str(br) + 'k'])
         if 'samplerate' in safe:
             optlist.extend(['-ar:a:' + stream, str(safe['samplerate'])])
+        if 'filter' in safe:
+            optlist.extend(['-filter:a:' + stream, str(safe['filter'])])
         if 'language' in safe:
                 lang = str(safe['language'])
         else:
@@ -518,6 +523,13 @@ class Ac3Codec(AudioCodec):
     """
     codec_name = 'ac3'
     ffmpeg_codec_name = 'ac3'
+    
+    def parse_options(self, opt, stream=0):
+        if 'channels' in opt:
+            c = opt['channels']
+            if c > 6:
+                opt['channels'] = 6
+        return super(Ac3Codec, self).parse_options(opt, stream)
 
 
 class FlacCodec(AudioCodec):

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -119,6 +119,7 @@ class MediaStreamInfo(object):
         self.video_width = None
         self.video_height = None
         self.video_fps = None
+        self.video_level = None
         self.audio_channels = None
         self.audio_samplerate = None
         self.attached_pic = None
@@ -194,6 +195,8 @@ class MediaStreamInfo(object):
                         self.video_fps = float(n) / float(d)
                 elif '.' in val:
                     self.video_fps = self.parse_float(val)
+            if key == 'level':
+                self.video_level = self.parse_float(val)
 
         if self.type == 'subtitle':
             if key == 'disposition:forced':

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -407,7 +407,7 @@ class FFMpeg(object):
 
         return info
 
-    def convert(self, infile, outfile, opts, timeout=10):
+    def convert(self, infile, outfile, opts, timeout=10, preopts=None, postopts=None):
         """
         Convert the source media (infile) according to specified options
         (a list of ffmpeg switches as strings) and save it to outfile.
@@ -434,7 +434,10 @@ class FFMpeg(object):
         if not os.path.exists(infile):
             raise FFMpegError("Input file doesn't exist: " + infile)
 
-        cmds = [self.ffmpeg_path, '-i', infile]
+        cmds = [self.ffmpeg_path]
+        if preopts:
+            cmds.extend(preopts)
+        cmds.extend(['-i', infile])
 
         # Move additional inputs to the front of the line
         for ind, command in enumerate(opts):
@@ -444,7 +447,8 @@ class FFMpeg(object):
                 del opts[ind]
 
         cmds.extend(opts)
-        cmds.extend(['-threads', 'auto'])
+        if postopts:
+            cmds.extend(postopts)
         cmds.extend(['-y', outfile])
 
         if timeout:
@@ -475,7 +479,14 @@ class FFMpeg(object):
             if not ret:
                 break
 
-            ret = ret.decode(console_encoding)
+            try:
+                ret = ret.decode(console_encoding)
+            except UnicodeDecodeError:
+                try:
+                    ret = ret.decode(console_encoding, errors="ignore")
+                except:
+                    pass
+
             total_output += ret
             buf += ret
             if '\r' in buf:

--- a/converter/formats.py
+++ b/converter/formats.py
@@ -92,7 +92,16 @@ class Mp3Format(BaseFormat):
     ffmpeg_format_name = 'mp3'
 
 
+class SrtFormat(BaseFormat):
+    """
+    Mp4 container format, the default Format for H.264
+    video content.
+    """
+    format_name = 'srt'
+    ffmpeg_format_name = 'srt'
+
+
 format_list = [
     OggFormat, AviFormat, MkvFormat, WebmFormat, FlvFormat,
-    MovFormat, Mp4Format, MpegFormat, Mp3Format
+    MovFormat, Mp4Format, MpegFormat, Mp3Format, SrtFormat
 ]

--- a/test/test.py
+++ b/test/test.py
@@ -75,6 +75,7 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(None, f.probe('/dev/null'))
 
         info = f.probe('test1.ogg')
+
         self.assertEqual('ogg', info.format.format)
         self.assertAlmostEqual(33.00, info.format.duration, places=2)
         self.assertEqual(2, len(info.streams))
@@ -87,23 +88,24 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(400, v.video_height)
         self.assertEqual(None, v.bitrate)
         self.assertAlmostEqual(25.00, v.video_fps, places=2)
-        self.assertEqual(v.metadata['ENCODER'], 'ffmpeg2theora 0.19')
+        self.assertEqual(v.metadata['encoder'], 'ffmpeg2theora 0.19')
 
         a = info.streams[1]
-        self.assertEqual(a, info.audio)
+        self.assertEqual(a, info.audio[0])
         self.assertEqual('audio', a.type)
         self.assertEqual('vorbis', a.codec)
         self.assertEqual(2, a.audio_channels)
         self.assertEqual(80000, a.bitrate)
         self.assertEqual(48000, a.audio_samplerate)
-        self.assertEqual(a.metadata['ENCODER'], 'ffmpeg2theora 0.19')
+        self.assertEqual(a.metadata['encoder'], 'ffmpeg2theora 0.19')
 
         self.assertEqual(repr(info), 'MediaInfo(format='
                                      'MediaFormatInfo(format=ogg, duration=33.00), streams=['
                                      'MediaStreamInfo(type=video, codec=theora, width=720, '
-                                     'height=400, fps=25.0, ENCODER=ffmpeg2theora 0.19), '
+                                     'height=400, fps=25.0, encoder=ffmpeg2theora 0.19), '
                                      'MediaStreamInfo(type=audio, codec=vorbis, channels=2, rate=48000, '
-                                     'bitrate=80000, ENCODER=ffmpeg2theora 0.19)])')
+                                     'bitrate=80000, encoder=ffmpeg2theora 0.19)])')
+        #self.assertEqual(repr(info), 'MediaStreamInfo(type=audio, codec=vorbis, channels=2, rate=48000, bitrate=80000, encoder=ffmpeg2theora 0.19) MediaStreamInfo(type=audio, codec=vorbis, channels=2, rate=48000, bitrate=80000, encoder=ffmpeg2theora 0.19)')
 
     def test_ffmpeg_convert(self):
         f = ffmpeg.FFMpeg()
@@ -212,7 +214,7 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(['-c:a:0', 'doctest', '-metadata:s:a:0', 'language=und'],
                          c.parse_options({'codec': 'doctest', 'channels': 0, 'bitrate': 0, 'samplerate': 0}))
 
-        self.assertEqual(['-acodec', 'doctest', '-ac', '1', '-ab', '64k', '-ar', '44100'],
+        self.assertEqual(['-c:a:0', 'doctest', '-ac:a:0', '1', '-b:a:0', '64k', '-ar:a:0', '44100', '-metadata:s:a:0', 'language=und'],
                          c.parse_options({'codec': 'doctest', 'channels': '1', 'bitrate': '64', 'samplerate': '44100'}))
 
         c = avcodecs.VideoCodec()
@@ -261,9 +263,9 @@ class TestFFMpeg(unittest.TestCase):
         self.assertRaisesSpecific(ConverterError, c.parse_options,
                                   {'format': 'ogg', 'audio': {'codec': 'bogus'}})
 
-        self.assertEqual(['-an', '-vcodec', 'libtheora', '-r', '25', '-sn', '-f', 'ogg'],
+        self.assertEqual(['-vcodec', 'libtheora', '-r', '25', '-an', '-sn', '-f', 'ogg'],
                          c.parse_options({'format': 'ogg', 'video': {'codec': 'theora', 'fps': 25}}))
-        self.assertEqual(['-acodec', 'copy', '-vcodec', 'copy', '-sn', '-f', 'ogg'],
+        self.assertEqual(['-vcodec', 'copy', '-c:a:0', 'copy', '-metadata:s:a:0', 'language=und', '-sn', '-f', 'ogg'],
                          c.parse_options({'format': 'ogg', 'audio': {'codec': 'copy'}, 'video': {'codec': 'copy'}, 'subtitle': {'codec': None}}))
 
         info = c.probe('test1.ogg')

--- a/test/test.py
+++ b/test/test.py
@@ -146,10 +146,10 @@ class TestFFMpeg(unittest.TestCase):
         self.assertEqual(200, info.video.video_height)
         self.assertAlmostEqual(15.00, info.video.video_fps, places=2)
 
-        self.assertEqual('audio', info.audio.type)
-        self.assertEqual('vorbis', info.audio.codec)
-        self.assertEqual(1, info.audio.audio_channels)
-        self.assertEqual(11025, info.audio.audio_samplerate)
+        self.assertEqual('audio', info.audio[0].type)
+        self.assertEqual('vorbis', info.audio[0].codec)
+        self.assertEqual(1, info.audio[0].audio_channels)
+        self.assertEqual(11025, info.audio[0].audio_samplerate)
 
     def test_ffmpeg_termination(self):
         # test when ffmpeg is killed
@@ -209,7 +209,7 @@ class TestFFMpeg(unittest.TestCase):
         c.codec_name = 'doctest'
         c.ffmpeg_codec_name = 'doctest'
 
-        self.assertEqual(['-acodec', 'doctest'],
+        self.assertEqual(['-c:a:0', 'doctest', '-metadata:s:a:0', 'language=und'],
                          c.parse_options({'codec': 'doctest', 'channels': 0, 'bitrate': 0, 'samplerate': 0}))
 
         self.assertEqual(['-acodec', 'doctest', '-ac', '1', '-ab', '64k', '-ar', '44100'],
@@ -257,7 +257,7 @@ class TestFFMpeg(unittest.TestCase):
 
         self.assertRaisesSpecific(ConverterError, c.parse_options, {'format': 'ogg'})
         self.assertRaisesSpecific(ConverterError, c.parse_options, {'format': 'ogg', 'video': 'whatever'})
-        self.assertRaisesSpecific(ConverterError, c.parse_options, {'format': 'ogg', 'audio': {}})
+        #self.assertRaisesSpecific(ConverterError, c.parse_options, {'format': 'ogg', 'audio': {}})
         self.assertRaisesSpecific(ConverterError, c.parse_options,
                                   {'format': 'ogg', 'audio': {'codec': 'bogus'}})
 

--- a/test/test.py
+++ b/test/test.py
@@ -211,7 +211,7 @@ class TestFFMpeg(unittest.TestCase):
         c.codec_name = 'doctest'
         c.ffmpeg_codec_name = 'doctest'
 
-        self.assertEqual(['-c:a:0', 'doctest', '-metadata:s:a:0', 'language=und'],
+        self.assertEqual(['-c:a:0', 'doctest', '-b:a:0', '8k', '-metadata:s:a:0', 'language=und'],
                          c.parse_options({'codec': 'doctest', 'channels': 0, 'bitrate': 0, 'samplerate': 0}))
 
         self.assertEqual(['-c:a:0', 'doctest', '-ac:a:0', '1', '-b:a:0', '64k', '-ar:a:0', '44100', '-metadata:s:a:0', 'language=und'],


### PR DESCRIPTION
Updated the modifications made in Sickbeard mp4 automator to the latest
version of python-video-converter in such a way that they are backwards
compatible with prior version unlike my last pull attempt.

Changes made here add the ability to output files with multiple audio
and subtitle tracks taking advantage of FFMPEGs -map function. Can pull
from multiple or single sources. to create complex files with different
tracks.

Options are presented as nested dictionaries now but previously used
style dictionaries are still compatible.

Tests will need to be updated
