### PR TITLE
[IMP] Add the possibility to define the number of threads used by ffmpeg

### DIFF
--- a/converter/__init__.py
+++ b/converter/__init__.py
@@ -121,9 +121,12 @@ class Converter(object):
             else:
                 format_options.extend(['-map', str(m)])
 
+        thread_opt = []
+        if 'threads' in opt:
+            thread_opt.extend(['-threads', str(opt['threads'])])
 
         # aggregate all options
-        optlist = audio_options + video_options + subtitle_options + format_options
+        optlist = audio_options + video_options + subtitle_options + format_options + thread_opt
 
         if twopass == 1:
             optlist.extend(['-pass', '1'])


### PR DESCRIPTION
To improve the performance of video encoding, ffmpeg is able to use multiple cores of the processor (See http://ffmpeg.org/pipermail/ffmpeg-user/2011-July/001735.html)

My pull request allows user to define the number of threads to use for the conversion. It adds a 

```
-threads nb_threads
```

options to ffmpeg. This option can be set by putting a key 'threads' with a number of threads to use in the Converter.convert() method.
