### PR TITLE
Compatibility with ffmpeg 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ python:
   - "3.2"
   - "3.3"
 
+env:
+  - FFMPEG_STATIC=http://ffmpeg.gusari.org/static/64bit/ffmpeg.static.64bit.2014-07-16.tar.gz
+  - FFMPEG_STATIC=http://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
+
 before_install:
- - sudo sh ./test/install-ffmpeg.sh
+ - sudo sh -x ./test/install-ffmpeg.sh $FFMPEG_STATIC
 
 script:
  - python setup.py test

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -453,8 +453,8 @@ class FFMpeg(object):
             ret = ret.decode(console_encoding)
             total_output += ret
             buf += ret
-            if '\r' in buf:
-                line, buf = buf.split('\r', 1)
+            if '\n' in buf:
+                line, buf = buf.split('\n', 1)
 
                 tmp = pat.findall(line)
                 if len(tmp) == 1:

--- a/test/install-ffmpeg.sh
+++ b/test/install-ffmpeg.sh
@@ -4,6 +4,8 @@
 # add-apt-repository -y ppa:jon-severinsson/ffmpeg
 # apt-get -y -qq update
 # apt-get -y -qq install ffmpeg
-# list directory of ffmpeg binary file there is in http://ffmpeg.gusari.org/static/64bit/
-wget -P /tmp http://ffmpeg.gusari.org/static/64bit/ffmpeg.static.64bit.latest.tar.gz
-tar -xvf /tmp/ffmpeg.static.64bit.latest.tar.gz -C /usr/local/bin
+# list directory of ffmpeg binary file there is in http://johnvansickle.com/ffmpeg/
+wget -O /tmp/ffmpeg-static $1
+mkdir /tmp/ffmpeg-bin/
+tar -xvf /tmp/ffmpeg-static -C /tmp/ffmpeg-bin/
+cp `find /tmp/ffmpeg-bin/ -name 'ff*' -executable -type f` /usr/local/bin


### PR DESCRIPTION
Output of ffmpeg 2.6 has changed and it no longer contains `\r` in output.
(Failed build with ffmpeg 2.6: https://travis-ci.org/tahajahangir/python-video-converter/builds/54536175)
