### PR TITLE
set close_fds to false for windows

### DIFF
--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -350,8 +350,9 @@ class FFMpeg(object):
     @staticmethod
     def _spawn(cmds):
         logger.debug('Spawning ffmpeg with command: ' + ' '.join(cmds))
+        close_fds = False if os.name == 'nt' else True
         return Popen(cmds, shell=False, stdin=PIPE, stdout=PIPE, stderr=PIPE,
-                     close_fds=True)
+                     close_fds=close_fds)
 
     def probe(self, fname, posters_as_video=True):
         """


### PR DESCRIPTION
`close_fds = True` is not supported in Windows throws an error.  Added a conditional so Windows will work.
