### PR TITLE
docs: Fix a few typos

### DIFF
--- a/converter/avcodecs.py
+++ b/converter/avcodecs.py
@@ -546,7 +546,7 @@ class MpegCodec(VideoCodec):
     # is not correctly preserved, so we have to set it
     # again in vf; take care to put it *before* crop/pad, so
     # it uses the same adjusted dimensions as the codec itself
-    # (pad/crop will adjust it further if neccessary)
+    # (pad/crop will adjust it further if necessary)
     def _codec_specific_parse_options(self, safe):
         w = safe['width']
         h = safe['height']

--- a/converter/ffmpeg.py
+++ b/converter/ffmpeg.py
@@ -499,7 +499,7 @@ class FFMpeg(object):
 
     def thumbnail(self, fname, time, outfile, size=None, quality=DEFAULT_JPEG_QUALITY):
         """
-        Create a thumbnal of media file, and store it to outfile
+        Create a thumbnail of media file, and store it to outfile
         @param time: time point (in seconds) (float or int)
         @param size: Size, if specified, is WxH of the desired thumbnail.
             If not specified, the video resolution is used.


### PR DESCRIPTION
There are small typos in:
- converter/avcodecs.py
- converter/ffmpeg.py

Fixes:
- Should read `thumbnail` rather than `thumbnal`.
- Should read `necessary` rather than `neccessary`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md